### PR TITLE
Added command in makefile to purge wasm from genesis json

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -194,7 +194,12 @@ genesis-remove-validator:
 	cp -fr $(GENESIS_COPY_PATH) $(GENESIS_LOCAL_PATH)
 	rm $(GENESIS_COPY_PATH)
 
-.PHONY: genesis-tools genesis-fetch genesis-add-validator genesis-remove-validator
+genesis-purge-wasm:
+	jq 'del(.app_state.wasm)' $(GENESIS_LOCAL_PATH) > $(GENESIS_COPY_PATH)
+	cp -fr $(GENESIS_COPY_PATH) $(GENESIS_LOCAL_PATH)
+	rm $(GENESIS_COPY_PATH)
+
+.PHONY: genesis-tools genesis-fetch genesis-add-validator genesis-remove-validator genesis-purge-wasm
 
 ###############################################################################
 ###                           Tests & Simulation                            ###


### PR DESCRIPTION
## Summary of changes

Added genesis tooling command to makefile that allows us to purge the wasm from genesis exports to help with https://github.com/classic-terra/classic/issues/12

## Report of required housekeeping

- [x] Github issue OR spec proposal link

----

## (FOR ADMIN) Before merging

- [x] Added appropriate labels to PR
- [x] Confirm added tests are consistent with the intended behavior of changes
- [x] Ensure all tests pass
