### PR TITLE
Disable ARM64 target to allow alpine build to pass

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -52,7 +52,7 @@ jobs:
           file: Dockerfile
           context: .
           push: true
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           tags: |
             ghcr.io/classic-terra/terraclassic.terrad-binary:${{ env.MAJOR_VERSION }}
             ghcr.io/classic-terra/terraclassic.terrad-binary:${{ env.MAJOR_VERSION }}.${{ env.MINOR_VERSION }}


### PR DESCRIPTION
I found out back in June that there was some issue when upgrading to the golang:1.19-alpine image when resolving the libwasm dependency on ARM64 architectures. That is why Woelig & I implemented the alternate Ubuntu based version, as it did not seem to suffer from the same issue and also made it easier for us to implement the "validator-auto-registration" logic to support the terra-operator. If this PR fixes the issue I would suggest that we consider targeting the Ubuntu image (Dockerfile.terraclassic.terrad-binary) as our default for the docker.yml workflow to support as many CPU architectures as possible. Alternately we can build both by extending the workflow with some more steps :)

## Summary of changes

Disabled linux/arm64 target in docker.yml workflow