### PR TITLE
allow uluna to be taxed

### DIFF
--- a/custom/auth/client/utils/feeutils.go
+++ b/custom/auth/client/utils/feeutils.go
@@ -15,9 +15,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/auth/legacy/legacytx"
 	"github.com/cosmos/cosmos-sdk/x/authz"
 
-	ante "github.com/terra-money/core/custom/auth/ante"
-	core "github.com/terra-money/core/types"
-
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 
 	marketexported "github.com/terra-money/core/x/market/exported"
@@ -265,10 +262,6 @@ func FilterMsgAndComputeTax(clientCtx client.Context, msgs ...sdk.Msg) (taxes sd
 // computes the stability tax according to tax-rate and tax-cap
 func computeTax(clientCtx client.Context, taxRate sdk.Dec, principal sdk.Coins) (taxes sdk.Coins, err error) {
 	for _, coin := range principal {
-
-		if coin.Denom == core.MicroLunaDenom && clientCtx.Height < ante.TaxPowerUpgradeHeight {
-			continue
-		}
 
 		taxCap, err := queryTaxCap(clientCtx, coin.Denom)
 		if err != nil {


### PR DESCRIPTION
## Summary of changes
The previous fix of adding the ante.TaxPowerUpgradeHeight did not pass integration testing.  The problem is that the clientCtx.Height is not equivalent to the chain height, and thus is never greater than the TaxPowerUpgradeHeight.
By simply removing this conditional, it will correctly tax uluna.  It is in the LCD client so it does not need to be wrapped in block height guards 

## Report of required housekeeping

- [ ] Github issue OR spec proposal link
- [ ] Wrote tests
- [ ] Updated API documentation (client/lcd/swagger-ui/swagger.yaml)
- [ ] Added a relevant changelog entry: clog add [section] [stanza] [message]

----

## (FOR ADMIN) Before merging

- [ ] Added appropriate labels to PR
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" (coding standards)
- [ ] Confirm added tests are consistent with the intended behavior of changes
- [ ] Ensure all tests pass
