### PR TITLE
Fix Panic when upgrade to v2

### DIFF
--- a/x/treasury/keeper/keeper.go
+++ b/x/treasury/keeper/keeper.go
@@ -356,8 +356,5 @@ func (k Keeper) GetBurnSplitRate(ctx sdk.Context) sdk.Dec {
 }
 
 func (k Keeper) SetBurnSplitRate(ctx sdk.Context, burnTaxSplit sdk.Dec) {
-	params := k.GetParams(ctx)
-	params.BurnTaxSplit = burnTaxSplit
-
-	k.SetParams(ctx, params)
+	k.paramSpace.Set(ctx, types.KeyBurnTaxSplit, burnTaxSplit)
 }

--- a/x/treasury/keeper/keeper.go
+++ b/x/treasury/keeper/keeper.go
@@ -349,12 +349,3 @@ func (k Keeper) ClearTSLs(ctx sdk.Context) {
 		store.Delete(iter.Key())
 	}
 }
-
-func (k Keeper) GetBurnSplitRate(ctx sdk.Context) sdk.Dec {
-	params := k.GetParams(ctx)
-	return params.BurnTaxSplit
-}
-
-func (k Keeper) SetBurnSplitRate(ctx sdk.Context, burnTaxSplit sdk.Dec) {
-	k.paramSpace.Set(ctx, types.KeyBurnTaxSplit, burnTaxSplit)
-}

--- a/x/treasury/keeper/params.go
+++ b/x/treasury/keeper/params.go
@@ -48,6 +48,17 @@ func (k Keeper) WindowProbation(ctx sdk.Context) (res uint64) {
 	return
 }
 
+// GetBurnSplitRate returns the burn split rate of treasury parameters.
+func (k Keeper) GetBurnSplitRate(ctx sdk.Context) sdk.Dec {
+	params := k.GetParams(ctx)
+	return params.BurnTaxSplit
+}
+
+// GetBurnSplitRate set the burn split rate of treasury parameters.
+func (k Keeper) SetBurnSplitRate(ctx sdk.Context, burnTaxSplit sdk.Dec) {
+	k.paramSpace.Set(ctx, types.KeyBurnTaxSplit, burnTaxSplit)
+}
+
 // GetParams returns the total set of treasury parameters.
 func (k Keeper) GetParams(ctx sdk.Context) (params types.Params) {
 	k.paramSpace.GetParamSet(ctx, &params)

--- a/x/treasury/keeper/params.go
+++ b/x/treasury/keeper/params.go
@@ -49,9 +49,9 @@ func (k Keeper) WindowProbation(ctx sdk.Context) (res uint64) {
 }
 
 // GetBurnSplitRate returns the burn split rate of treasury parameters.
-func (k Keeper) GetBurnSplitRate(ctx sdk.Context) sdk.Dec {
-	params := k.GetParams(ctx)
-	return params.BurnTaxSplit
+func (k Keeper) GetBurnSplitRate(ctx sdk.Context) (res sdk.Dec) {
+	k.paramSpace.Get(ctx, types.KeyBurnTaxSplit, &res)
+	return
 }
 
 // GetBurnSplitRate set the burn split rate of treasury parameters.


### PR DESCRIPTION
## Summary of changes
- Change logic`SetBurnSplitRate`. It should be set directly in paramspace. 

<Describe summary of major changes here>

## Report of required housekeeping

- [ ] Github issue OR spec proposal link
- [ ] Wrote tests
- [ ] Updated API documentation (client/lcd/swagger-ui/swagger.yaml)
- [ ] Added a relevant changelog entry: clog add [section] [stanza] [message]

----

## (FOR ADMIN) Before merging

- [ ] Added appropriate labels to PR
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" (coding standards)
- [ ] Confirm added tests are consistent with the intended behavior of changes
- [ ] Ensure all tests pass
