### PR TITLE
Fix makefile for linux builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,15 +115,15 @@ endif
 
 build-linux:
 	mkdir -p $(BUILDDIR)
-	docker build --no-cache --tag classic-terra/terraclassic.terrad-binary ./
-	docker create --name temp classic-terra/terraclassic.terrad-binary:latest
+	docker build --platform linux/amd64 --no-cache --tag classic-terra/terraclassic.terrad-binary ./
+	docker create --platform linux/amd64 --name temp classic-terra/terraclassic.terrad-binary:latest
 	docker cp temp:/usr/local/bin/terrad $(BUILDDIR)/
 	docker rm temp
 
 build-linux-with-shared-library:
 	mkdir -p $(BUILDDIR)
-	docker build --tag classic-terra/terraclassic.terrad-shared ./ -f ./shared.Dockerfile
-	docker create --name temp classic-terra/terraclassic.terrad-shared:latest
+	docker build --platform linux/amd64 --tag classic-terra/terraclassic.terrad-shared ./ -f ./shared.Dockerfile
+	docker create --platform linux/amd64 --name temp classic-terra/terraclassic.terrad-shared:latest
 	docker cp temp:/usr/local/bin/terrad $(BUILDDIR)/
 	docker cp temp:/lib/libwasmvm.so $(BUILDDIR)/
 	docker rm temp


### PR DESCRIPTION
## Summary of changes
This PR fixes image build errors on Apple Silicon machines, and removes warnings from Docker when using the image.

## Report of required housekeeping

- [ ] Github issue OR spec proposal link
- [ ] Wrote tests
- [ ] Updated API documentation (client/lcd/swagger-ui/swagger.yaml)
- [ ] Added a relevant changelog entry: clog add [section] [stanza] [message]

----

## (FOR ADMIN) Before merging

- [ ] Added appropriate labels to PR
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" (coding standards)
- [ ] Confirm added tests are consistent with the intended behavior of changes
- [ ] Ensure all tests pass
