### PR TITLE
add logic for whitelist-concept

### DIFF
--- a/custom/auth/ante/burntax.go
+++ b/custom/auth/ante/burntax.go
@@ -109,6 +109,8 @@ func (btfd BurnTaxFeeDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate 
 					taxMsgs = append(taxMsgs, taxMsg)
 				}
 			}
+		} else {
+			taxMsgs = msgs
 		}
 
 		taxes := FilterMsgAndComputeTax(ctx, btfd.TreasuryKeeper, taxMsgs...)

--- a/custom/auth/ante/burntax.go
+++ b/custom/auth/ante/burntax.go
@@ -1,8 +1,6 @@
 package ante
 
 import (
-	"strings"
-
 	treasury "github.com/terra-money/core/x/treasury/types"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -37,50 +35,50 @@ func NewBurnTaxFeeDecorator(treasuryKeeper TreasuryKeeper, bankKeeper BankKeeper
 	}
 }
 
-var BurnTaxAddressWhitelist = []string{
-	"terra10atxpzafqfjy58z0dvugmd9zf63fycr6uvwhjm",
-	"terra1jrq7xa63a4qgpdgtj70k8yz5p32ps9r7mlj3yr",
-	"terra15s66unmdcpknuxxldd7fsr44skme966tdckq8c",
-	"terra1u0p7xuwlg0zsqgntagdkyjyumsegd8agzhug99",
-	"terra1fax8l6srhew5tu2mavmu83js3v7vsqf9yr4fv7",
-	"terra132wegs0kf9q65t9gsm3g2y06l98l2k4treepkq",
-	"terra1l89hprfccqxgzzypjzy3fnp7vqpnkqg5vvqgjc",
-	"terra1ns7lfvrxzter4d2yl9tschdwntcxa25vtsvd8a",
-	"terra1vuvju6la7pj6t8d8zsx4g8ea85k2cg5u62cdhl",
-	"terra1lzdux37s4anmakvg7pahzh03zlf43uveq83wh2",
-	"terra1ky3qcf7v45n6hwfmkm05acwczvlq8ahnq778wf",
-	"terra17m8tkde0mav43ckeehp537rsz4usqx5jayhf08",
-	"terra1urj8va62jeygra7y3a03xeex49mjddh3eul0qa",
-	"terra10wyptw59xc52l86pg86sy0xcm3nm5wg6a3cf7l",
-	"terra1sujaqwaw7ls9fh6a4x7n06nv7fxx5xexwlnrkf",
-	"terra1qg59nhvag222kp6fyzxt83l4sw02huymqnklww",
-	"terra1dxxnwxlpjjkl959v5xrghx0dtvut60eef6vcch",
-	"terra1y246m036et7vu69nsg4kapelj0tywe8vsmp34d",
-	"terra1j39c9sjr0zpjnrfjtthuua0euecv7txavxvq36",
-	"terra1t0jthtq9zhm4ldtvs9epp02zp23f355wu6zrzq",
-	"terra12dxclvqrgt7w3s7gtwpdkxgymexv8stgqcr0yu",
-	"terra1az3dsad74pwhylrrexnn5qylzj783uyww2s7xz",
-	"terra1ttq26dq4egr5exmhd6gezerrxhlutx9u90uncn",
-	"terra13e9670yuvfs06hctt9pmgjnz0yw28p0wgnhrqn",
-	"terra1skmktm537pfaycgu9jx4fqryjt6pf77ycpesw0",
-	"terra14q8cazgt58y2xkd26mlukemwth0cnvfqmgz2qk",
-	"terra163vzxz9wwy320ccwy73qe6h33yzg2yhyvv5nsf",
-	"terra1kj43wfnvrgc2ep94dgmwvnzv8vnkkxrxmrnhkp",
-	"terra1gu6re549pn0mdpshtv75t3xugn347jghlhul73",
-	"terra1gft3qujlq04yza3s2r238mql2yn3xxqepzt2up",
-	"terra174pe7qe7g867spzdfs5f4rf9fuwmm42zf4hykf",
-	"terra1ju68sg6k39t385sa0fazqvjgh6m6gkmsmp4lln",
-	"terra1dlh7k4hcnsrvlfuzhdzx3ctynj7s8dde9zmdyd",
-	"terra18wcdhpzpteharlkks5n6k7ent0mjyftvcpm6ee",
-	"terra1xmkwsauuk3kafua9k23hrkfr76gxmwdfq5c09d",
-	"terra1t957gces65xd6p8g4cuqnyd0sy5tzku59njydd",
-	"terra1s4rd0y5e4gasf0krdm2w8sjhsmh030m74f2x9v",
-	"terra15jya6ugxp65y80y5h82k4gv90pd7acv58xp6jj",
-	"terra14yqy9warjkxyecda5kf5a68qlknf4ve4sh7sa6",
-	"terra1yxras4z0fs9ugsg2hew9334k65uzejwcslyx0y",
-	"terra1p0vl4s4gp46vy6dm352s2fgtw6hccypph7zc3u",
-	"terra1hhj92twle9x8rjkr3yffujexsy5ldexak5rglz",
-	"terra18vnrzlzm2c4xfsx382pj2xndqtt00rvhu24sqe",
+var BurnTaxAddressWhitelist = map[string]byte{
+	"terra10atxpzafqfjy58z0dvugmd9zf63fycr6uvwhjm": 1,
+	"terra1jrq7xa63a4qgpdgtj70k8yz5p32ps9r7mlj3yr": 1,
+	"terra15s66unmdcpknuxxldd7fsr44skme966tdckq8c": 1,
+	"terra1u0p7xuwlg0zsqgntagdkyjyumsegd8agzhug99": 1,
+	"terra1fax8l6srhew5tu2mavmu83js3v7vsqf9yr4fv7": 1,
+	"terra132wegs0kf9q65t9gsm3g2y06l98l2k4treepkq": 1,
+	"terra1l89hprfccqxgzzypjzy3fnp7vqpnkqg5vvqgjc": 1,
+	"terra1ns7lfvrxzter4d2yl9tschdwntcxa25vtsvd8a": 1,
+	"terra1vuvju6la7pj6t8d8zsx4g8ea85k2cg5u62cdhl": 1,
+	"terra1lzdux37s4anmakvg7pahzh03zlf43uveq83wh2": 1,
+	"terra1ky3qcf7v45n6hwfmkm05acwczvlq8ahnq778wf": 1,
+	"terra17m8tkde0mav43ckeehp537rsz4usqx5jayhf08": 1,
+	"terra1urj8va62jeygra7y3a03xeex49mjddh3eul0qa": 1,
+	"terra10wyptw59xc52l86pg86sy0xcm3nm5wg6a3cf7l": 1,
+	"terra1sujaqwaw7ls9fh6a4x7n06nv7fxx5xexwlnrkf": 1,
+	"terra1qg59nhvag222kp6fyzxt83l4sw02huymqnklww": 1,
+	"terra1dxxnwxlpjjkl959v5xrghx0dtvut60eef6vcch": 1,
+	"terra1y246m036et7vu69nsg4kapelj0tywe8vsmp34d": 1,
+	"terra1j39c9sjr0zpjnrfjtthuua0euecv7txavxvq36": 1,
+	"terra1t0jthtq9zhm4ldtvs9epp02zp23f355wu6zrzq": 1,
+	"terra12dxclvqrgt7w3s7gtwpdkxgymexv8stgqcr0yu": 1,
+	"terra1az3dsad74pwhylrrexnn5qylzj783uyww2s7xz": 1,
+	"terra1ttq26dq4egr5exmhd6gezerrxhlutx9u90uncn": 1,
+	"terra13e9670yuvfs06hctt9pmgjnz0yw28p0wgnhrqn": 1,
+	"terra1skmktm537pfaycgu9jx4fqryjt6pf77ycpesw0": 1,
+	"terra14q8cazgt58y2xkd26mlukemwth0cnvfqmgz2qk": 1,
+	"terra163vzxz9wwy320ccwy73qe6h33yzg2yhyvv5nsf": 1,
+	"terra1kj43wfnvrgc2ep94dgmwvnzv8vnkkxrxmrnhkp": 1,
+	"terra1gu6re549pn0mdpshtv75t3xugn347jghlhul73": 1,
+	"terra1gft3qujlq04yza3s2r238mql2yn3xxqepzt2up": 1,
+	"terra174pe7qe7g867spzdfs5f4rf9fuwmm42zf4hykf": 1,
+	"terra1ju68sg6k39t385sa0fazqvjgh6m6gkmsmp4lln": 1,
+	"terra1dlh7k4hcnsrvlfuzhdzx3ctynj7s8dde9zmdyd": 1,
+	"terra18wcdhpzpteharlkks5n6k7ent0mjyftvcpm6ee": 1,
+	"terra1xmkwsauuk3kafua9k23hrkfr76gxmwdfq5c09d": 1,
+	"terra1t957gces65xd6p8g4cuqnyd0sy5tzku59njydd": 1,
+	"terra1s4rd0y5e4gasf0krdm2w8sjhsmh030m74f2x9v": 1,
+	"terra15jya6ugxp65y80y5h82k4gv90pd7acv58xp6jj": 1,
+	"terra14yqy9warjkxyecda5kf5a68qlknf4ve4sh7sa6": 1,
+	"terra1yxras4z0fs9ugsg2hew9334k65uzejwcslyx0y": 1,
+	"terra1p0vl4s4gp46vy6dm352s2fgtw6hccypph7zc3u": 1,
+	"terra1hhj92twle9x8rjkr3yffujexsy5ldexak5rglz": 1,
+	"terra18vnrzlzm2c4xfsx382pj2xndqtt00rvhu24sqe": 1,
 }
 
 // AnteHandle handles msg tax fee checking
@@ -103,55 +101,17 @@ func (btfd BurnTaxFeeDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate 
 
 	if !simulate {
 		// Compute taxes again.
-		taxes := FilterMsgAndComputeTax(ctx, btfd.TreasuryKeeper, msgs...)
+		var taxMsgs []sdk.Msg
 
 		if currHeight >= WhitelistHeight {
 			for _, msg := range msgs {
-				var whitelistedRecipients []string
-				var whitelistedSigners []string
-				recipientWhitelistCount := 0
-
-				switch v := msg.(type) {
-				case *banktypes.MsgSend:
-					whitelistedRecipients = append(whitelistedRecipients, v.ToAddress)
-				case *banktypes.MsgMultiSend:
-					for _, output := range v.Outputs {
-						whitelistedRecipients = append(whitelistedRecipients, output.Address)
-					}
-				default:
-					// TODO: We might want to return an error if we cannot match the msg types, but as such I think that means we also need to cover MsgSetSendEnabled & MsgUpdateParams
-					// return ctx, sdkerrors.Wrap(sdkerrors.ErrInvalidType, "Unsupported message type")
-				}
-
-				signers := msg.GetSigners()
-
-				for _, signer := range signers {
-					signerAddress := signer.String()
-
-					for _, whitelistEntry := range BurnTaxAddressWhitelist {
-						if !strings.EqualFold(signerAddress, whitelistEntry) {
-							break
-						}
-
-						whitelistedSigners = append(whitelistedSigners, signerAddress)
-					}
-				}
-
-				for _, recipient := range whitelistedRecipients {
-					for _, whitelistEntry := range BurnTaxAddressWhitelist {
-						if !strings.EqualFold(recipient, whitelistEntry) {
-							break
-						}
-
-						recipientWhitelistCount++
-					}
-				}
-
-				if len(signers) == len(whitelistedSigners) && len(whitelistedRecipients) <= recipientWhitelistCount {
-					return next(ctx, tx, simulate)
+				if taxMsg := checkMessageWhitelist(msg); taxMsg != nil {
+					taxMsgs = append(taxMsgs, taxMsg)
 				}
 			}
 		}
+
+		taxes := FilterMsgAndComputeTax(ctx, btfd.TreasuryKeeper, taxMsgs...)
 
 		// Record tax proceeds
 		if !taxes.IsZero() {
@@ -182,4 +142,73 @@ func (btfd BurnTaxFeeDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate 
 	}
 
 	return next(ctx, tx, simulate)
+}
+
+func checkMessageWhitelist(msg sdk.Msg) sdk.Msg {
+	var whitelistedRecipients []string
+	var whitelistedSenders []string
+	recipientWhitelistCount := 0
+	senderWhitelistCount := 0
+	binancePositionInSet := map[int]byte{}
+
+	switch v := msg.(type) {
+	case *banktypes.MsgSend:
+		whitelistedSenders = append(whitelistedSenders, v.FromAddress)
+		whitelistedRecipients = append(whitelistedRecipients, v.ToAddress)
+	case *banktypes.MsgMultiSend:
+		for _, input := range v.Inputs {
+			whitelistedSenders = append(whitelistedSenders, input.Address)
+		}
+
+		for _, output := range v.Outputs {
+			whitelistedRecipients = append(whitelistedRecipients, output.Address)
+		}
+	default:
+		return msg
+		// TODO: We might want to return an error if we cannot match the msg types, but as such I think that means we also need to cover MsgSetSendEnabled & MsgUpdateParams
+		// return ctx, sdkerrors.Wrap(sdkerrors.ErrInvalidType, "Unsupported message type")
+	}
+
+	// extract subset
+	for i, sender := range whitelistedSenders {
+		if _, ok := BurnTaxAddressWhitelist[sender]; ok {
+			senderWhitelistCount += 1
+			binancePositionInSet[i] = 1
+		}
+	}
+
+	for i, recipient := range whitelistedRecipients {
+		if _, ok := BurnTaxAddressWhitelist[recipient]; ok {
+			recipientWhitelistCount += 1
+			binancePositionInSet[i] = 1
+		}
+	}
+
+	// filter out case 1 -> 5, only 6 -> 9 left
+	if senderWhitelistCount == len(whitelistedSenders) || recipientWhitelistCount == len(whitelistedRecipients) {
+		return nil
+	}
+
+	// filter out case 9, only 6 -> 8 left
+	if !(senderWhitelistCount == 0 && recipientWhitelistCount == 0) {
+		newTaxMsg := banktypes.MsgMultiSend{
+			Inputs:  []banktypes.Input{},
+			Outputs: []banktypes.Output{},
+		}
+
+		// if not binance pair, add pair to taxMsg for tax calculation
+		msgMultiSend := msg.(*banktypes.MsgMultiSend)
+		for i := 0; i < len(whitelistedSenders); i++ {
+			if _, ok := binancePositionInSet[i]; ok {
+				continue
+			}
+
+			newTaxMsg.Inputs = append(newTaxMsg.Inputs, msgMultiSend.Inputs[i])
+			newTaxMsg.Outputs = append(newTaxMsg.Outputs, msgMultiSend.Outputs[i])
+		}
+
+		return &newTaxMsg
+	}
+
+	return msg
 }

--- a/custom/auth/ante/burntax_test.go
+++ b/custom/auth/ante/burntax_test.go
@@ -1,6 +1,8 @@
 package ante_test
 
 import (
+	"fmt"
+
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
 	"github.com/cosmos/cosmos-sdk/testutil/testdata"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -8,8 +10,10 @@ import (
 
 	"github.com/terra-money/core/custom/auth/ante"
 	core "github.com/terra-money/core/types"
+	treasury "github.com/terra-money/core/x/treasury/types"
 
 	"github.com/cosmos/cosmos-sdk/types/query"
+	cosmosante "github.com/cosmos/cosmos-sdk/x/auth/ante"
 	"github.com/cosmos/cosmos-sdk/x/auth/types"
 	minttypes "github.com/cosmos/cosmos-sdk/x/mint/types"
 )
@@ -90,102 +94,207 @@ func (suite *AnteTestSuite) TestEnsureBurnTaxModule() {
 
 // the following binance addresses should not be applied tax
 // go test -v -run ^TestAnteTestSuite/TestFilterRecipient$ github.com/terra-money/core/custom/auth/ante
-// func (suite *AnteTestSuite) TestFilterRecipient() {
+//
+// N is set of all Binance whitelist addresses
+// “Inputs” is set of all sender address
+// “Outputs” is set of all recipient address
+// There is one - to - one correspondence between the elements of the two sets
+// (in, out) is a pair of element from two sets
+//
+// sender1 -> amount1 -> receiver1 (Inputs[0]-Outputs[0])
+// sender2 -> amount2 -> receiver2 (Inputs[1]-Outputs[1])
+// sender3 -> amount3 -> receiver3 (Inputs[2]-Outputs[2])
+//
+// case 1: ∀Inputs ∊ N, ∀Outputs ∊ N -> ∀(in, out) pass
+// case 2: ∀Inputs ∊ N, ∃Outputs ∊ N -> ∀(in, out) pass
+// case 3: ∃Inputs ∊ N, ∀Outputs ∊ N -> ∀(in, out) pass
+// case 4: ∄Inputs ∊ N, ∀Outputs ∊ N -> ∀(in, out) pass
+// case 5: ∀Inputs ∊ N, ∄Outputs ∊ N -> ∀(in, out) pass
+// case 6: ∃Inputs ∊ N, ∃Outputs ∊ N -> ∃(in, out) ∊ N pass, ∃(in, out) ∉ N tax
+// case 7: ∃Inputs ∊ N, ∄Outputs ∊ N -> ∃(in, out) ∊ N pass, ∃(in, out) ∉ N tax
+// case 8: ∄Inputs ∊ N, ∃Outputs ∊ N -> ∃(in, out) ∊ N pass, ∃(in, out) ∉ N tax
+// case 9: ∄Inputs ∊ N, ∄Outputs ∊ N -> ∀(in, out) tax
+//
+// E = ∀Inputs ∊ N || ∀Outputs ∊ N -> ∀(in, out) pass
+// E1 = ∄Inputs ∊ N && ∄Outputs ∊ N -> ∀(in, out) tax
+// Default: calculate tax cut for ∃(in, out) ∉ N
 
-// 	// keys and addresses
-// 	priv1, _, addr1 := testdata.KeyTestPubAddr()
-// 	priv2, _, addr2 := testdata.KeyTestPubAddr()
-// 	_, _, addr3 := testdata.KeyTestPubAddr()
-// 	ante.BurnTaxAddressWhitelist = []string{
-// 		addr1.String(),
-// 	}
+func (suite *AnteTestSuite) TestFilterRecipient() {
 
-// 	cases := []struct {
-// 		name             string
-// 		senderAddress    sdk.AccAddress
-// 		senderPriv       cryptotypes.PrivKey
-// 		recipientAddress sdk.AccAddress
-// 		burnShouldWork   bool
-// 	}{
-// 		{
-// 			name:             "send token from binance address",
-// 			senderAddress:    addr1,
-// 			senderPriv:       priv1,
-// 			recipientAddress: addr2,
-// 			burnShouldWork:   false,
-// 		}, {
-// 			name:             "token received by binance address",
-// 			senderAddress:    addr2,
-// 			senderPriv:       priv2,
-// 			recipientAddress: addr1,
-// 			burnShouldWork:   false,
-// 		}, {
-// 			name:             "normal tax cut",
-// 			senderAddress:    addr2,
-// 			senderPriv:       priv2,
-// 			recipientAddress: addr3,
-// 			burnShouldWork:   true,
-// 		},
-// 	}
+	// keys and addresse
+	// 1 and 2 is binance whitelist address
+	//3 and 4 is normal address
+	priv1, _, addr1 := testdata.KeyTestPubAddr()
+	priv2, _, addr2 := testdata.KeyTestPubAddr()
+	priv3, _, addr3 := testdata.KeyTestPubAddr()
+	_, _, addr4 := testdata.KeyTestPubAddr()
+	ante.BurnTaxAddressWhitelist = map[string]byte{
+		addr1.String(): 1,
+		addr2.String(): 1,
+	}
 
-// 	// there should be no coin in burn module
-// 	for _, c := range cases {
-// 		fmt.Printf("CASE = %s \n", c.name)
-// 		suite.SetupTest(true) // setup
-// 		suite.ctx = suite.ctx.WithBlockHeight(ante.TaxPowerSplitHeight)
-// 		suite.txBuilder = suite.clientCtx.TxConfig.NewTxBuilder()
+	sendAmount := int64(1000000)
+	sendCoins := sdk.NewCoins(sdk.NewInt64Coin(core.MicroSDRDenom, sendAmount))
 
-// 		sendAmount := int64(1000000)
-// 		sendCoins := sdk.NewCoins(sdk.NewInt64Coin(core.MicroSDRDenom, sendAmount))
-// 		fundCoins := sdk.NewCoins(sdk.NewInt64Coin(core.MicroSDRDenom, 2000000))
-// 		acc := suite.app.AccountKeeper.NewAccountWithAddress(suite.ctx, c.senderAddress)
-// 		suite.app.AccountKeeper.SetAccount(suite.ctx, acc)
-// 		suite.app.BankKeeper.MintCoins(suite.ctx, minttypes.ModuleName, fundCoins)
-// 		suite.app.BankKeeper.SendCoinsFromModuleToAccount(suite.ctx, minttypes.ModuleName, c.senderAddress, fundCoins)
+	cases := []struct {
+		name            string
+		inputAddresses  []banktypes.Input
+		senderPriv      cryptotypes.PrivKey
+		outputAddresses []banktypes.Output
+		shouldTax       int64
+		blockHeight     int64
+	}{
+		{
+			name: "send token from one of binance address",
+			inputAddresses: []banktypes.Input{
+				{
+					Address: addr1.String(),
+					Coins:   sendCoins,
+				}, {
+					Address: addr3.String(),
+					Coins:   sendCoins,
+				}},
+			senderPriv: priv1,
+			outputAddresses: []banktypes.Output{
+				{
+					Address: addr4.String(),
+					Coins:   sendCoins,
+				}, {
+					Address: addr4.String(),
+					Coins:   sendCoins,
+				}},
+			shouldTax:   1000,
+			blockHeight: ante.WhitelistHeight,
+		}, {
+			name: "token received by one of binance address",
+			inputAddresses: []banktypes.Input{
+				{
+					Address: addr3.String(),
+					Coins:   sendCoins,
+				}, {
+					Address: addr4.String(),
+					Coins:   sendCoins,
+				}},
+			senderPriv: priv3,
+			outputAddresses: []banktypes.Output{
+				{
+					Address: addr1.String(),
+					Coins:   sendCoins,
+				}, {
+					Address: addr3.String(),
+					Coins:   sendCoins,
+				}},
+			shouldTax:   1000,
+			blockHeight: ante.WhitelistHeight,
+		}, {
+			name: "normal tax cut for two normal address",
+			inputAddresses: []banktypes.Input{
+				{
+					Address: addr3.String(),
+					Coins:   sendCoins,
+				}, {
+					Address: addr4.String(),
+					Coins:   sendCoins,
+				}},
+			senderPriv: priv3,
+			outputAddresses: []banktypes.Output{
+				{
+					Address: addr4.String(),
+					Coins:   sendCoins,
+				}, {
+					Address: addr3.String(),
+					Coins:   sendCoins,
+				}},
+			shouldTax:   2000,
+			blockHeight: ante.WhitelistHeight,
+		}, {
+			name: "send token from one of binance address to one of binance address",
+			inputAddresses: []banktypes.Input{
+				{
+					Address: addr2.String(),
+					Coins:   sendCoins,
+				}, {
+					Address: addr3.String(),
+					Coins:   sendCoins,
+				}},
+			senderPriv: priv2,
+			outputAddresses: []banktypes.Output{
+				{
+					Address: addr4.String(),
+					Coins:   sendCoins,
+				}, {
+					Address: addr1.String(),
+					Coins:   sendCoins,
+				}},
+			shouldTax:   0,
+			blockHeight: ante.WhitelistHeight,
+		},
+	}
 
-// 		mfd := ante.NewBurnTaxFeeDecorator(suite.app.TreasuryKeeper, suite.app.BankKeeper, suite.app.DistrKeeper)
-// 		antehandler := sdk.ChainAnteDecorators(
-// 			cosmosante.NewDeductFeeDecorator(suite.app.AccountKeeper, suite.app.BankKeeper, suite.app.FeeGrantKeeper),
-// 			mfd,
-// 		)
+	// there should be no coin in burn module
+	for _, c := range cases {
+		fmt.Printf("CASE = %s \n", c.name)
+		suite.SetupTest(true) // setup
+		suite.ctx = suite.ctx.WithBlockHeight(c.blockHeight)
+		suite.txBuilder = suite.clientCtx.TxConfig.NewTxBuilder()
 
-// 		// msg and signatures
-// 		msg := banktypes.NewMsgSend(c.senderAddress, c.recipientAddress, sendCoins)
+		for _, input := range c.inputAddresses {
+			fundCoins := sdk.NewCoins(sdk.NewInt64Coin(core.MicroSDRDenom, 2000000))
+			addr := sdk.MustAccAddressFromBech32(input.Address)
+			acc := suite.app.AccountKeeper.NewAccountWithAddress(suite.ctx, addr)
+			suite.app.AccountKeeper.SetAccount(suite.ctx, acc)
+			suite.app.BankKeeper.MintCoins(suite.ctx, minttypes.ModuleName, fundCoins)
+			suite.app.BankKeeper.SendCoinsFromModuleToAccount(suite.ctx, minttypes.ModuleName, addr, fundCoins)
+		}
 
-// 		feeAmount := sdk.NewCoins(sdk.NewInt64Coin(core.MicroSDRDenom, 1000))
-// 		gasLimit := testdata.NewTestGasLimit()
-// 		suite.Require().NoError(suite.txBuilder.SetMsgs(msg))
-// 		suite.txBuilder.SetFeeAmount(feeAmount)
-// 		suite.txBuilder.SetGasLimit(gasLimit)
+		mfd := ante.NewBurnTaxFeeDecorator(suite.app.TreasuryKeeper, suite.app.BankKeeper, suite.app.DistrKeeper)
+		antehandler := sdk.ChainAnteDecorators(
+			cosmosante.NewDeductFeeDecorator(suite.app.AccountKeeper, suite.app.BankKeeper, suite.app.FeeGrantKeeper),
+			mfd,
+		)
 
-// 		privs, accNums, accSeqs := []cryptotypes.PrivKey{c.senderPriv}, []uint64{0}, []uint64{0}
-// 		tx, err := suite.CreateTestTx(privs, accNums, accSeqs, suite.ctx.ChainID())
-// 		suite.Require().NoError(err)
+		// msg and signatures
+		msg := banktypes.NewMsgMultiSend(c.inputAddresses, c.outputAddresses)
 
-// 		// check fee decorator and burn module amount before ante handler
-// 		feeCollector := suite.app.AccountKeeper.GetModuleAccount(suite.ctx, types.FeeCollectorName)
-// 		burnModule := suite.app.AccountKeeper.GetModuleAccount(suite.ctx, treasury.BurnModuleName)
+		feeAmount := sdk.NewCoins(sdk.NewInt64Coin(core.MicroSDRDenom, c.shouldTax))
+		if c.shouldTax == 0 {
+			feeAmount = sdk.NewCoins(sdk.NewInt64Coin(core.MicroSDRDenom, 1000))
+		}
+		gasLimit := testdata.NewTestGasLimit()
+		suite.Require().NoError(suite.txBuilder.SetMsgs(msg))
+		suite.txBuilder.SetFeeAmount(feeAmount)
+		suite.txBuilder.SetGasLimit(gasLimit)
 
-// 		amountFeeBefore := suite.app.BankKeeper.GetBalance(suite.ctx, feeCollector.GetAddress(), core.MicroSDRDenom)
-// 		fmt.Printf("amount fee before = %v \n", amountFeeBefore)
-// 		amountBurnBefore := suite.app.BankKeeper.GetBalance(suite.ctx, burnModule.GetAddress(), core.MicroSDRDenom)
-// 		fmt.Printf("amount burn before = %v \n", amountBurnBefore)
+		privs, accNums, accSeqs := []cryptotypes.PrivKey{c.senderPriv}, []uint64{0}, []uint64{0}
+		tx, err := suite.CreateTestTx(privs, accNums, accSeqs, suite.ctx.ChainID())
+		suite.Require().NoError(err)
 
-// 		_, err = antehandler(suite.ctx, tx, false)
-// 		suite.Require().NoError(err)
+		// check fee decorator and burn module amount before ante handler
+		feeCollector := suite.app.AccountKeeper.GetModuleAccount(suite.ctx, types.FeeCollectorName)
+		burnModule := suite.app.AccountKeeper.GetModuleAccount(suite.ctx, treasury.BurnModuleName)
 
-// 		// check fee decorator
-// 		amountFee := suite.app.BankKeeper.GetBalance(suite.ctx, feeCollector.GetAddress(), core.MicroSDRDenom)
-// 		fmt.Printf("amount fee = %v \n", amountFee)
-// 		amountBurn := suite.app.BankKeeper.GetBalance(suite.ctx, burnModule.GetAddress(), core.MicroSDRDenom)
-// 		fmt.Printf("amount burn before = %v \n", amountBurn)
+		amountFeeBefore := suite.app.BankKeeper.GetBalance(suite.ctx, feeCollector.GetAddress(), core.MicroSDRDenom)
+		fmt.Printf("amount fee before = %v \n", amountFeeBefore)
+		amountBurnBefore := suite.app.BankKeeper.GetBalance(suite.ctx, burnModule.GetAddress(), core.MicroSDRDenom)
+		fmt.Printf("amount burn before = %v \n", amountBurnBefore)
 
-// 		if c.burnShouldWork {
-// 			suite.Require().Equal(amountBurnBefore.Amount.Add(sdk.NewInt(1000)), amountBurn.Amount)
-// 			suite.Require().Equal(amountFeeBefore, amountFee)
-// 		} else {
-// 			suite.Require().Equal(amountBurnBefore, amountBurn)
-// 			suite.Require().Equal(amountFeeBefore.Amount.Add(sdk.NewInt(1000)), amountFee.Amount)
-// 		}
-// 	}
-// }
+		_, err = antehandler(suite.ctx, tx, false)
+		suite.Require().NoError(err)
+
+		// check fee decorator
+		amountFee := suite.app.BankKeeper.GetBalance(suite.ctx, feeCollector.GetAddress(), core.MicroSDRDenom)
+		fmt.Printf("amount fee = %v \n", amountFee)
+		amountBurn := suite.app.BankKeeper.GetBalance(suite.ctx, burnModule.GetAddress(), core.MicroSDRDenom)
+		fmt.Printf("amount burn before = %v \n", amountBurn)
+
+		if c.shouldTax > 0 {
+			// if should tax, send tax from fee collector to burn module
+			suite.Require().Equal(amountBurnBefore.Amount.Add(sdk.NewInt(c.shouldTax)), amountBurn.Amount)
+			suite.Require().Equal(amountFeeBefore, amountFee)
+		} else {
+			// if no tax, tax will remain in fee collector
+			suite.Require().Equal(amountBurnBefore, amountBurn)
+			suite.Require().Equal(amountFeeBefore.Amount.Add(sdk.NewInt(1000)), amountFee.Amount)
+		}
+	}
+}

--- a/custom/auth/ante/burntax_test.go
+++ b/custom/auth/ante/burntax_test.go
@@ -18,6 +18,7 @@ import (
 	minttypes "github.com/cosmos/cosmos-sdk/x/mint/types"
 )
 
+// go test -v -run ^TestAnteTestSuite/TestEnsureBurnTaxModule$ github.com/terra-money/core/custom/auth/ante
 func (suite *AnteTestSuite) TestEnsureBurnTaxModule() {
 	suite.SetupTest(true) // setup
 	suite.txBuilder = suite.clientCtx.TxConfig.NewTxBuilder()


### PR DESCRIPTION
## Summary of changes

Tax is calculated for each Input and Output in MsgMultiSend
-> pair that has Binance address will not be taxed
-> pair that has normal address will not be taxed also (which is wrong)
-> current logic only check if Binance address is in MsgMultiSend then skip all

**I. Combinatorics**

N is set of all Binance whitelist addresses
“Inputs” is set of all sender address
“Outputs” is set of all recipient address
There is one - to - one correspondence between the elements of the two sets
(in, out) is a pair of element from two sets

sender1 -> amount1 -> receiver1 (Inputs[0]-Outputs[0])
sender2 -> amount2 -> receiver2 (Inputs[1]-Outputs[1])
sender3 -> amount3 -> receiver3 (Inputs[2]-Outputs[2])

∀Inputs ∊ N, ∀Outputs ∊ N -> ∀(in, out) pass
∀Inputs ∊ N, ∃Outputs ∊ N -> ∀(in, out) pass
∃Inputs ∊ N, ∀Outputs ∊ N -> ∀(in, out) pass
∄Inputs ∊ N, ∀Outputs ∊ N -> ∀(in, out) pass
∀Inputs ∊ N, ∄Outputs ∊ N -> ∀(in, out) pass
∃Inputs ∊ N, ∃Outputs ∊ N -> ∃(in, out) ∊ N pass, ∃(in, out) ∉ N tax
∃Inputs ∊ N, ∄Outputs ∊ N -> ∃(in, out) ∊ N pass, ∃(in, out) ∉ N tax
∄Inputs ∊ N, ∃Outputs ∊ N -> ∃(in, out) ∊ N pass, ∃(in, out) ∉ N tax
∄Inputs ∊ N, ∄Outputs ∊ N -> ∀(in, out) tax

E = ∀Inputs ∊ N || ∀Outputs ∊ N -> ∀(in, out) pass
E1 = ∄Inputs ∊ N && ∄Outputs ∊ N -> ∀(in, out) tax
Default: calculate tax cut for ∃(in, out) ∉ N

**II. Features**

1. Why not using signers as a filter feature? Should use sender address on each Msg directly.
* In case of signers >1, signers are component of multi - signature address. All signer addresses are different from multi - signature address. If sender is multi - signature address in Binance list, and signers are not on the list. This will produce unwanted tax on sender.
* For list of Msg, we only need to support Msg types that are supported by FilterMsgAndComputeTax(). Those will be few cases needed to cover for sender address.

2. For creation of taxMsgs, since Msgs can contain something like this:
Msgs[MsgSend{binance -> binance}, MsgSend{normal -> normal}]

it is best that we create a specific taxMsg where we left out binance Msg and still calculate tax for normal Msg like so, taxMsgs[MsgSend{normal -> normal}]

**III. Testing**

four test cases presented in burntax_test.go are all pass with mix of binance pair and normal pair in a MsgMultiSend. Gas is calculated and burned correctly.

## Report of required housekeeping

- [ ] Github issue OR spec proposal link
- [ ] Wrote tests
- [ ] Updated API documentation (client/lcd/swagger-ui/swagger.yaml)
- [ ] Added a relevant changelog entry: clog add [section] [stanza] [message]

----

## (FOR ADMIN) Before merging

- [ ] Added appropriate labels to PR
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" (coding standards)
- [ ] Confirm added tests are consistent with the intended behavior of changes
- [ ] Ensure all tests pass
